### PR TITLE
add facility to test AbstractRNG's

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ The first argument to the test function must be either
 
 * a function without arguments, which must return a `Float64` between zero and one, or
 
-* a wrapped `AbstractRNG` obtained via the function `wrap(rng, T)` where `T` is the
-   type of number one wants tested (currently `T` must be one of the standard
+* a wrapped `AbstractRNG` obtained via the function `wrap(rng, T)`
+   where `T` is the type of the variates produced by `rng` that one
+   wants tested (currently `T` must be one of the standard
    finite-precision Julia `Integer` or `FloatingPoint` types).
 
 The output from the test is a p-value.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,25 @@
 # The Crush test suite of l'Ecuyer for Julia
 [![Build Status](https://travis-ci.org/andreasnoack/RNGTest.jl.png)](https://travis-ci.org/andreasnoack/RNGTest.jl)
 
-The package is a Julia interface to the test suite TestU01 of Pierre l'Ecuyer. All the tests included in the SmallCrush and BigCrush test batteries can be called as Julia functions. The first argument to the test function must be a function without arguments and it must return a `Float64` between zero and one. The output from the test is a p-value. The package also includes the Small- and the BigCrush batteries. Some examples:
+The package is a Julia interface to the test suite TestU01 of Pierre l'Ecuyer. All the tests included in the SmallCrush and BigCrush test batteries can be called as Julia functions.
+The first argument to the test function must be either
+
+* a function without arguments, which must return a `Float64` between zero and one, or
+
+* a wrapped `AbstractRNG` obtained via the function `wrap(rng, T)` where `T` is the
+   type of number one wants tested (currently `T` must be one of the standard
+   finite-precision Julia `Integer` or `FloatingPoint` types).
+
+The output from the test is a p-value.
+The package also includes the Small- and the BigCrush batteries. Some examples:
 ```julia
 julia> using RNGTest
 julia> RNGTest.smallcrushJulia(rand)
 julia> using Distribtions
 julia> gf() = cdf(Gamma(), rand(Gamma()));
 julia> RNGTest.bigcrushJulia(gf)
+julia> rng = RNGTest.wrap(MersenneTwister(), UInt32)
+julia> RNGTest.bigcrushTestU01(rng)
 ```
 Note that the BigCrush test battery takes about twelve hours on a normal computer.
 

--- a/src/RNGTest.jl
+++ b/src/RNGTest.jl
@@ -7,9 +7,88 @@ module RNGTest
 	swrite = cglobal(("swrite_Basic", libtestu01), Ptr{Bool})
 	unsafe_store!(swrite, 0, 1)
 
+        # WrappedRNG
+
+        typealias TestableNumbers Union(Base.IntTypes..., Float16, Float32, Float64)
+
+        type WrappedRNG{T<:TestableNumbers, RNG<:AbstractRNG}
+            rng::RNG
+            cache::Vector{T}
+            fillarray::Bool
+            vals::Vector{UInt32}
+            idx::Int
+        end
+
+        function WrappedRNG{RNG, T}(rng::RNG, ::Type{T}, fillarray = true, cache_size = 3*2^11 ÷ sizeof(T))
+            if T <: Integer && cache_size*sizeof(T) % sizeof(UInt32) != 0
+                error("cache_size must be a multiple of $(Int(4/sizeof(T))) (for type $T)")
+            elseif T === Float16 && cache_size % 6 != 0 || T === Float32 && cache_size % 3 != 0
+                error("cache_size must be a multiple of 3 (resp. 6) for Float32 (resp. Float16)")
+            end
+            cache = Array(T, cache_size)
+            fillcache(WrappedRNG{T, RNG}(rng, cache, fillarray,
+                                         pointer_to_array(convert(Ptr{UInt32}, pointer(cache)), sizeof(cache)÷sizeof(UInt32)),
+                                         0)) # 0 is a dummy value, which will be set correctly by fillcache
+        end
+
+        # The ability to play with the cache size and the fillarray option is for advanced uses,
+        # when one wants to test different code path of the particular RNG implementations, like
+        # MersenneTwister from Base.
+        # For now let's document only the type parameter in the wrap function:
+        wrap{T<:TestableNumbers}(rng::AbstractRNG, ::Type{T}) = WrappedRNG(rng, T)
+
+        function fillcache{T}(g::WrappedRNG{T})
+            if g.fillarray
+                rand!(g.rng, g.cache)
+            else
+                for i = 1:length(g.cache)
+                    @inbounds g.cache[i] = rand(g.rng, T)
+                end
+            end
+            g.idx = 0
+            return g
+        end
+
+        function callUnif01{T<:Integer}(g::WrappedRNG{T})
+            g.idx+1 > length(g.vals) && fillcache(g)
+            @inbounds return g.vals[g.idx+=1]
+        end
+
+        function callUnif01(g::WrappedRNG{Float64})
+            g.idx+1 > length(g.cache) && fillcache(g)
+            @inbounds return g.cache[g.idx+=1]
+        end
+
+        function callUnif01(g::WrappedRNG{Float32})
+            g.idx+3 > length(g.cache) && fillcache(g)
+            @inbounds begin
+                f = Float64(g.cache[g.idx+1])
+                # a Float32 has 24 bits of precision, but only 23 bit of entropy
+                f += Float64(g.cache[g.idx+2])/exp2(23)
+                f += Float64(g.cache[g.idx+=3])/exp2(46)
+                return f % 1.0
+            end
+        end
+
+        function callUnif01(g::WrappedRNG{Float16})
+            g.idx+6 > length(g.cache) && fillcache(g)
+            @inbounds begin
+                f = Float64(g.cache[g.idx+1])
+                # a Float16 has 10 bits of entropy
+                f += Float64(g.cache[g.idx+2])/exp2(10)
+                f += Float64(g.cache[g.idx+3])/exp2(20)
+                f += Float64(g.cache[g.idx+4])/exp2(30)
+                f += Float64(g.cache[g.idx+5])/exp2(40)
+                f += Float64(g.cache[g.idx+=6])/exp2(50)
+                return f % 1.0
+            end
+        end
+
+
 	# Generator type
 	type Unif01
 		ptr::Ptr{Array{Int32}}
+		gentype::Type
 		name::ASCIIString
 		function Unif01(f::Function, genname)
 			for i in 1:100
@@ -18,14 +97,34 @@ module RNGTest
 				if tmp < 0 || tmp > 1 error("Function must return values on [0,1]") end
 			end
 			cf = cfunction(f, Float64, ())
-			b = new(ccall((:unif01_CreateExternGen01, libtestu01), Ptr{Void}, (Ptr{Uint8}, Ptr{Void}), genname, cf))
-			#finalizer(b, delete) # TestU01 crashed if two unif01 object are generated. The only safe thing is to explicitly delete the object when used. 
+			b = new(ccall((:unif01_CreateExternGen01, libtestu01), Ptr{Void}, (Ptr{Uint8}, Ptr{Void}), genname, cf), Float64)
+			#finalizer(b, delete) # TestU01 crashed if two unif01 object are generated. The only safe thing is to explicitly delete the object when used.
 			return b
 		end
+
+                function Unif01{T<:FloatingPoint}(g::WrappedRNG{T}, genname)
+                    # we assume that g being created out of an AbstractRNG, it produces Floats in the interval [0,1)
+                    @eval f() = callUnif01($g) :: Float64
+                    cf = cfunction(f, Float64, ())
+                    return new(ccall((:unif01_CreateExternGen01, libtestu01), Ptr{Void}, (Ptr{Uint8}, Ptr{Void}), genname, cf), Float64)
+                end
+
+                function Unif01{T<:Integer}(g::WrappedRNG{T}, genname)
+                    @assert Cuint === UInt32
+                    @eval f() = callUnif01($g) :: UInt32
+                    cf = cfunction(f, UInt32, ())
+                    return new(ccall((:unif01_CreateExternGenBits, libtestu01), Ptr{Void}, (Ptr{Uint8}, Ptr{Void}), genname, cf), UInt32)
+                end
 	end
 	function delete(obj::Unif01)
-		ccall((:unif01_DeleteExternGen01, libtestu01), Void, (Ptr{Void},), obj.ptr)
+            if obj.gentype === Float64
+                ccall((:unif01_DeleteExternGen01, libtestu01), Void, (Ptr{Void},), obj.ptr)
+            else
+                ccall((:unif01_DeleteExternGenBits, libtestu01), Void, (Ptr{Void},), obj.ptr)
+            end
 	end
+
+        typealias Generator Union(Function, WrappedRNG)
 
 	# Result types
 
@@ -339,7 +438,7 @@ module RNGTest
 	# Tests #
 	#########
 	## smarsa
-	function smarsa_BirthdaySpacings(gen::Function, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer, p::Integer)
+	function smarsa_BirthdaySpacings(gen::Generator, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer, p::Integer)
 	 	unif01 = Unif01(gen, "")
 	 	sres = ResPoisson()
 	 	ccall((:smarsa_BirthdaySpacings, libtestu01), Void, 
@@ -350,7 +449,7 @@ module RNGTest
 	 	delete(unif01)
 	 	return pvalue(sres)
 	end
-	function smarsa_GCD(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer)
+	function smarsa_GCD(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer)
 	 	unif01 = Unif01(gen, "")
 	 	sres = MarsaRes2(N)
 	 	ccall((:smarsa_GCD, libtestu01), Void, 
@@ -360,8 +459,8 @@ module RNGTest
 	 		r, s)
 	 	delete(unif01)
 	 	return pvalue(sres)
-	end	
-	function smarsa_CollisionOver(gen::Function, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer)
+	end
+	function smarsa_CollisionOver(gen::Generator, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer)
 	 	unif01 = Unif01(gen, "")
 	 	sres = MarsaRes()
 	 	ccall((:smarsa_CollisionOver, libtestu01), Void, 
@@ -372,7 +471,7 @@ module RNGTest
 	 	delete(unif01)
 	 	return pvalue(sres)
 	end
-	function smarsa_Savir2(gen::Function, N::Integer, n::Integer, r::Integer, m::Integer, t::Integer)
+	function smarsa_Savir2(gen::Generator, N::Integer, n::Integer, r::Integer, m::Integer, t::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:smarsa_Savir2, libtestu01), Void, 
@@ -382,8 +481,8 @@ module RNGTest
 			 r, m, t)
 		delete(unif01)
 		return pvalue(sres)
-	end	
-	function smarsa_SerialOver(gen::Function, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer)
+	end
+	function smarsa_SerialOver(gen::Generator, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer)
 	 	unif01 = Unif01(gen, "")
 	 	sres = ResBasic()
 	 	ccall((:smarsa_SerialOver, libtestu01), Void, 
@@ -394,7 +493,7 @@ module RNGTest
 	 	delete(unif01)
 	 	return pvalue(sres)
 	end
-	function smarsa_MatrixRank(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer, k::Integer)
+	function smarsa_MatrixRank(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer, k::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:smarsa_MatrixRank, libtestu01), Void, 
@@ -407,7 +506,7 @@ module RNGTest
 	end
 
 	## sknuth
-	function sknuth_Collision(gen::Function, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer)
+	function sknuth_Collision(gen::Generator, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer)
 		unif01 = Unif01(gen, "")
 		sres = KnuthRes2()
 		ccall((:sknuth_Collision, libtestu01), Void, 
@@ -418,7 +517,7 @@ module RNGTest
 		delete(unif01)
 	 	return pvalue(sres)
 	end
-	function sknuth_CollisionPermut(gen::Function, N::Integer, n::Integer, r::Integer, t::Integer)
+	function sknuth_CollisionPermut(gen::Generator, N::Integer, n::Integer, r::Integer, t::Integer)
 		unif01 = Unif01(gen, "")
 		sres = KnuthRes2()
 		ccall((:sknuth_CollisionPermut, libtestu01), Void, 
@@ -428,8 +527,8 @@ module RNGTest
 			 r, t)
 		delete(unif01)
 		return pvalue(sres)
-	end	
-	function sknuth_CouponCollector(gen::Function, N::Integer, n::Integer, r::Integer, d::Integer)
+	end
+	function sknuth_CouponCollector(gen::Generator, N::Integer, n::Integer, r::Integer, d::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:sknuth_CouponCollector, libtestu01), Void, 
@@ -440,7 +539,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function sknuth_Gap(gen::Function, N::Integer, n::Integer, r::Integer, Alpha::Real, Beta::Real)
+	function sknuth_Gap(gen::Generator, N::Integer, n::Integer, r::Integer, Alpha::Real, Beta::Real)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:sknuth_Gap, libtestu01), Void, 
@@ -451,7 +550,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function sknuth_MaxOft(gen::Function, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer)
+	function sknuth_MaxOft(gen::Generator, N::Integer, n::Integer, r::Integer, d::Integer, t::Integer)
 		unif01 = Unif01(gen, "")
 		sres = KnuthRes1(N)
 		ccall((:sknuth_MaxOft, libtestu01), Void, 
@@ -461,8 +560,8 @@ module RNGTest
 			 r, d, t)
 		delete(unif01)
 		return pvalue(sres)
-	end		
-	function sknuth_Permutation(gen::Function, N::Integer, n::Integer, r::Integer, t::Integer)
+	end
+	function sknuth_Permutation(gen::Generator, N::Integer, n::Integer, r::Integer, t::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:sknuth_Permutation, libtestu01), Void, 
@@ -472,8 +571,8 @@ module RNGTest
 			 r, t)
 		delete(unif01)
 		return pvalue(sres)
-	end		
-	function sknuth_Run(gen::Function, N::Integer, n::Integer, r::Integer, up::Integer)
+	end
+	function sknuth_Run(gen::Generator, N::Integer, n::Integer, r::Integer, up::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:sknuth_Run, libtestu01), Void, 
@@ -483,8 +582,8 @@ module RNGTest
 			 r, up)
 		delete(unif01)
 		return pvalue(sres)
-	end	
-	function sknuth_SimpPoker(gen::Function, N::Integer, n::Integer, r::Integer, d::Integer, k::Integer)
+	end
+	function sknuth_SimpPoker(gen::Generator, N::Integer, n::Integer, r::Integer, d::Integer, k::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:sknuth_SimpPoker, libtestu01), Void, 
@@ -497,7 +596,7 @@ module RNGTest
 	end
 
 	## svaria
-	function svaria_AppearanceSpacings(gen::Function, N::Integer, Q::Integer, K::Integer, r::Integer, s::Integer, L::Integer)
+	function svaria_AppearanceSpacings(gen::Generator, N::Integer, Q::Integer, K::Integer, r::Integer, s::Integer, L::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResBasic()
 		ccall((:svaria_AppearanceSpacings, libtestu01), Void, 
@@ -508,7 +607,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function svaria_SampleProd(gen::Function, N::Integer, n::Integer, r::Integer, t::Integer)
+	function svaria_SampleProd(gen::Generator, N::Integer, n::Integer, r::Integer, t::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResBasic()
 		ccall((:svaria_SampleProd, libtestu01), Void, 
@@ -519,7 +618,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function svaria_SampleMean(gen::Function, N::Integer, n::Integer, r::Integer)
+	function svaria_SampleMean(gen::Generator, N::Integer, n::Integer, r::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResBasic()
 		ccall((:svaria_SampleMean, libtestu01), Void, 
@@ -530,7 +629,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function svaria_SampleCorr(gen::Function, N::Integer, n::Integer, r::Integer, k::Integer)
+	function svaria_SampleCorr(gen::Generator, N::Integer, n::Integer, r::Integer, k::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResBasic()
 		ccall((:svaria_SampleCorr, libtestu01), Void, 
@@ -541,7 +640,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function svaria_SumCollector(gen::Function, N::Integer, n::Integer, r::Integer, g::Float64)
+	function svaria_SumCollector(gen::Generator, N::Integer, n::Integer, r::Integer, g::Float64)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:svaria_SumCollector, libtestu01), Void, 
@@ -552,7 +651,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function svaria_WeightDistrib(gen::Function, N::Integer, n::Integer, r::Integer, k::Integer, alpha::Real, beta::Real)
+	function svaria_WeightDistrib(gen::Generator, N::Integer, n::Integer, r::Integer, k::Integer, alpha::Real, beta::Real)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:svaria_WeightDistrib, libtestu01), Void, 
@@ -565,7 +664,7 @@ module RNGTest
 	end
 
 	## sstring
-	function sstring_AutoCor(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer, d::Integer)
+	function sstring_AutoCor(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer, d::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResBasic()
 		ccall((:sstring_AutoCor, libtestu01), Void, 
@@ -575,8 +674,8 @@ module RNGTest
 			 r, s, d)
 		delete(unif01)
 		return pvalue(sres)
-	end	
-	function sstring_HammingCorr(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer)
+	end
+	function sstring_HammingCorr(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer)
 		unif01 = Unif01(gen, "")
 		sres = StringRes()
 		ccall((:sstring_HammingCorr, libtestu01), Void, 
@@ -587,7 +686,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function sstring_HammingIndep(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer, d::Integer)
+	function sstring_HammingIndep(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer, d::Integer)
 		unif01 = Unif01(gen, "")
 		sres = StringRes()
 		ccall((:sstring_HammingIndep, libtestu01), Void, 
@@ -598,7 +697,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function sstring_HammingWeight2(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer)
+	function sstring_HammingWeight2(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResBasic()
 		ccall((:sstring_HammingWeight2, libtestu01), Void, 
@@ -609,7 +708,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function sstring_LongestHeadRun(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer)
+	function sstring_LongestHeadRun(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer, L::Integer)
 		unif01 = Unif01(gen, "")
 		sres = StringRes2(N)
 		ccall((:sstring_LongestHeadRun, libtestu01), Void, 
@@ -620,7 +719,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function sstring_PeriodsInStrings(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer)
+	function sstring_PeriodsInStrings(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResChi2(N)
 		ccall((:sstring_PeriodsInStrings, libtestu01), Void, 
@@ -630,8 +729,8 @@ module RNGTest
 			 r, s)
 		delete(unif01)
 		return pvalue(sres)
-	end	
-	function sstring_Run(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer)
+	end
+	function sstring_Run(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer)
 		unif01 = Unif01(gen, "")
 		sres = StringRes3(N)
 		ccall((:sstring_Run, libtestu01), Void, 
@@ -645,7 +744,7 @@ module RNGTest
 
 
 	## swalk
-	function swalk_RandomWalk1(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer, L0::Integer, L1::Integer)
+	function swalk_RandomWalk1(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer, L0::Integer, L1::Integer)
 		unif01 = Unif01(gen, "")
 		sres = WalkRes(N)
 		ccall((:swalk_RandomWalk1, libtestu01), Void, 
@@ -658,7 +757,7 @@ module RNGTest
 	end
 
 	## snpair
-	function snpair_ClosePairs(gen::Function, N::Integer, n::Integer, r::Integer, t::Integer, p::Integer, m::Integer)
+	function snpair_ClosePairs(gen::Generator, N::Integer, n::Integer, r::Integer, t::Integer, p::Integer, m::Integer)
 		unif01 = Unif01(gen, "")
 		sres = NpairRes(N)
 		ccall((:snpair_ClosePairs, libtestu01), Void, 
@@ -671,7 +770,7 @@ module RNGTest
 	end
 
 	## scomp
-	function scomp_LempelZiv(gen::Function, N::Integer, k::Integer, r::Integer, s::Integer)
+	function scomp_LempelZiv(gen::Generator, N::Integer, k::Integer, r::Integer, s::Integer)
 		unif01 = Unif01(gen, "")
 		sres = ResBasic()
 		ccall((:scomp_LempelZiv, libtestu01), Void, 
@@ -682,7 +781,7 @@ module RNGTest
 		delete(unif01)
 		return pvalue(sres)
 	end
-	function scomp_LinearComp(gen::Function, N::Integer, n::Integer, r::Integer, s::Integer)
+	function scomp_LinearComp(gen::Generator, N::Integer, n::Integer, r::Integer, s::Integer)
 		unif01 = Unif01(gen, "")
 		sres = CompRes(N)
 		ccall((:scomp_LinearComp, libtestu01), Void, 
@@ -695,7 +794,7 @@ module RNGTest
 	end
 
 	# sspectral
-	function sspectral_Fourier3(gen::Function, N::Integer, k::Integer, r::Integer, s::Integer)
+	function sspectral_Fourier3(gen::Generator, N::Integer, k::Integer, r::Integer, s::Integer)
 		unif01 = Unif01(gen, "")
 		sres = SpectralRes()
 		ccall((:sspectral_Fourier3, libtestu01), Void, 
@@ -712,15 +811,15 @@ module RNGTest
 	##################
 	for (snm, fnm) in ((:SmallCrush, :smallcrushTestU01), (:Crush, :crushTestU01), (:BigCrush, :bigcrushTestU01), (:pseudoDIEHARD, :diehardTestU01), (:FIPS_140_2, :fips_140_2TestU01))
 		@eval begin
-			function $(fnm)(f::Function, fname::String)
+			function $(fnm)(f::Generator, fname::String)
 				unif01 = Unif01(f, fname)
 				ccall(($(string("bbattery_", snm)), libtestu01), Void, (Ptr{Void},), unif01.ptr)
 				delete(unif01)
 			end
-			$(fnm)(f::Function) = $(fnm)(f::Function, "")
+			$(fnm)(f::Generator) = $(fnm)(f::Generator, "")
 		end
 	end
- 	function smallcrushJulia(f::Function)
+ 	function smallcrushJulia(f::Generator)
  		# @everywhere f = ()->g()
  		testnames = [g->smarsa_BirthdaySpacings(g, 1, 5000000, 0, 1073741824, 2, 1),
  					 g->sknuth_Collision(g, 1, 5000000, 0, 65536, 2),
@@ -734,7 +833,7 @@ module RNGTest
  					 g->swalk_RandomWalk1(g, 1, 1000000, 0, 30, 150, 150)]
  		return pmap(t->t(f), testnames)
  	end
- 	function bigcrushJulia(f::Function)
+ 	function bigcrushJulia(f::Generator)
  		testnames = [g->smarsa_SerialOver(g, 1, 10^9, 0, 2^8, 3)[:Mean],
  					 g->smarsa_SerialOver(g, 1, 10^9, 22, 2^8, 3)[:Mean],
  					 g->smarsa_CollisionOver(g, 30, 2*10^7, 0, 2^21, 2),


### PR DESCRIPTION
This should make it easier to test rngs which have the `AbstractRNG` interface. 
I'm really not good at choosing names, so I will change them on request.